### PR TITLE
Add client.loop_forever() for auto-reconnect

### DIFF
--- a/hc2mqtt
+++ b/hc2mqtt
@@ -31,6 +31,7 @@ def hc2mqtt(config_file: str, mqtt_host: str, mqtt_prefix: str):
 		thread = Thread(target=client_connect, args=(client, device, mqtt_topic))
 		thread.start()
 
+	client.loop_forever()
 
 
 # Map their value names to easier state names


### PR DESCRIPTION
Fix for https://github.com/osresearch/hcpy/issues/21

Even though hc2mqtt was running, and showed active log lines, I stopped receiving the messages sometimes in the MQTT server and subscribed processes.

Adding client.loop_forever() will auto-reconnect to the mqtt server in case of network loss / hickups. Seems to help for my setup.

Docs: https://pypi.org/project/paho-mqtt/#network-loop

And thanks for the great hack/tool! Super!

I was using the cloud API to monitor washing-machine progress, but that's quite a flaky setup, loosing access/tokens every now and again if their cloud is offline for a bit. This direct connection is much better! ;-)