### PR TITLE
Prevent hostless requests in hc-login (#34)

### DIFF
--- a/hc-login
+++ b/hc-login
@@ -168,6 +168,8 @@ while True:
 	if r.status_code != 302:
 		break
 	return_url = r.headers["location"]
+	if return_url.startswith("/"):
+		return_url = singlekey_host + return_url
 	if return_url.startswith("hcauth://"):
 		break
 debug(f"{return_url=}")


### PR DESCRIPTION
This pull requests ensures that the `singlekey_host` variable is prepended when the `return_url` starts with a `/`. See issue #34 for details.