### PR TITLE
Handle 307 redirects in hc-login (#35)

### DIFF
--- a/hc-login
+++ b/hc-login
@@ -165,7 +165,7 @@ if return_url.startswith("/"):
 while True:
 	r = session.get(return_url, allow_redirects=False)
 	debug(f"{return_url=}, {r} {r.text}")
-	if r.status_code != 302:
+	if r.status_code != 302 and r.status_code != 307:
 		break
 	return_url = r.headers["location"]
 	if return_url.startswith("hcauth://"):


### PR DESCRIPTION
Properly handle `307` redirects, in the same way `302` redirects are already handled. See issue #35 and https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_redirection.